### PR TITLE
Add comment for sessionID field

### DIFF
--- a/content/docs/wrp/simple-messages.md
+++ b/content/docs/wrp/simple-messages.md
@@ -103,4 +103,4 @@ partner_ids | (optional) The list of partner ids the message is meant to target.
 headers | (optional) The headers associated with the payload.
 metadata | (optional) The map of name/value pairs used by consumers of WRP messages for filtering & other purposes.
 payload | The bin format packed data.
-sessionID | A unique ID for the source device's connection session with XMiDT
+sessionID | A unique ID for the device's connection session with XMiDT

--- a/content/docs/wrp/simple-messages.md
+++ b/content/docs/wrp/simple-messages.md
@@ -72,7 +72,7 @@ payload | The msgpack binary format packed data.
 
 This is one of the primary message definitions used.  It provides a one
 directional (no responses needed or sent) message from a component to whatever
-happens to be listening.  It's alot like a UDP message, but it's over TCP and
+happens to be listening.  It's a lot like a UDP message, but it's over TCP and
 TLS.  Generally the `dest` is targeted to an `event:some_event_type_here/ignored`
 which flows out to the event listeners for consumption.  This message type is
 great at sending metrics, publishing a report, sending an SOS.
@@ -89,6 +89,7 @@ great at sending metrics, publishing a report, sending an SOS.
     Array.String headers
     Map[String] metadata
     Binary payload
+    String sessionID
 }
 ~~~~~
 
@@ -102,3 +103,4 @@ partner_ids | (optional) The list of partner ids the message is meant to target.
 headers | (optional) The headers associated with the payload.
 metadata | (optional) The map of name/value pairs used by consumers of WRP messages for filtering & other purposes.
 payload | The bin format packed data.
+sessionID | A unique ID for the source device's connection session with XMiDT

--- a/docs/docs/wrp/simple-messages/index.html
+++ b/docs/docs/wrp/simple-messages/index.html
@@ -295,7 +295,7 @@ great at sending metrics, publishing a report, sending an SOS.</p>
 </tr>
 <tr>
 <td>sessionID</td>
-<td>A unique ID for the source device's connection session with XMiDT</td>
+<td>A unique ID for the device's connection session with XMiDT</td>
 </tr>
 </tbody>
 </table>

--- a/docs/docs/wrp/simple-messages/index.html
+++ b/docs/docs/wrp/simple-messages/index.html
@@ -232,7 +232,7 @@ the same message type.</p>
 
 <p>This is one of the primary message definitions used.  It provides a one
 directional (no responses needed or sent) message from a component to whatever
-happens to be listening.  It's alot like a UDP message, but it's over TCP and
+happens to be listening.  It's a lot like a UDP message, but it's over TCP and
 TLS.  Generally the <code>dest</code> is targeted to an <code>event:some_event_type_here/ignored</code>
 which flows out to the event listeners for consumption.  This message type is
 great at sending metrics, publishing a report, sending an SOS.</p>
@@ -249,6 +249,7 @@ great at sending metrics, publishing a report, sending an SOS.</p>
     Array.String headers
     Map[String] metadata
     Binary payload
+    String sessionID
 }
 </code></pre>
 
@@ -291,6 +292,10 @@ great at sending metrics, publishing a report, sending an SOS.</p>
 <tr>
 <td>payload</td>
 <td>The bin format packed data.</td>
+</tr>
+<tr>
+<td>sessionID</td>
+<td>A unique ID for the source device's connection session with XMiDT</td>
 </tr>
 </tbody>
 </table>

--- a/docs/download/index.html
+++ b/docs/download/index.html
@@ -121,9 +121,9 @@
       <thead>
         <tr>
           <td colspan="5">
-            <strong>0.2.2 / 19-11-2019</strong>
+            <strong></strong>
             
-            <small><a href="https://github.com/xmidt-org/caduceus/releases/tag/v0.2.2">Release notes</a></small>
+            <small><a href="https://github.com/xmidt-org/caduceus/releases/tag/v0.2.3">Release notes</a></small>
           </td>
         </tr>
         <tr class="first">
@@ -137,47 +137,20 @@
       </thead>
       <tbody>
       
-        <tr data-os="el7" data-arch="x86_64">
-          <td class="filename"><a class="download" href="https://github.com/xmidt-org/caduceus/releases/download/v0.2.2/caduceus-0.2.2-1.el7.x86_64.rpm">caduceus-0.2.2-1.el7.x86_64.rpm</a></td>
-          <td>el7</td>
-          <td>x86_64</td>
-          <td>10.09 MiB</td>
-          <td>rpm</td>
-          <td class="checksum">eeedb3f0a9926c3c2dff740739dc5ce86a0f2ffdc95e5aef41e62c8eb0053f79</td>
-        </tr>
-      
-        <tr data-os="darwin" data-arch="amd64">
-          <td class="filename"><a class="download" href="https://github.com/xmidt-org/caduceus/releases/download/v0.2.2/caduceus-0.2.2.darwin-amd64.tar.gz">caduceus-0.2.2.darwin-amd64.tar.gz</a></td>
-          <td>darwin</td>
-          <td>amd64</td>
-          <td>11.03 MiB</td>
-          <td>tar.gz</td>
-          <td class="checksum">5d215056fac2e5e84016ce3e8e898ecf2bb7aad29dbba86eb5c2091fcdf9cb3e</td>
-        </tr>
-      
-        <tr data-os="linux" data-arch="amd64">
-          <td class="filename"><a class="download" href="https://github.com/xmidt-org/caduceus/releases/download/v0.2.2/caduceus-0.2.2.linux-amd64.tar.gz">caduceus-0.2.2.linux-amd64.tar.gz</a></td>
-          <td>linux</td>
-          <td>amd64</td>
-          <td>11.19 MiB</td>
-          <td>tar.gz</td>
-          <td class="checksum">2f9261691042b0b667088da7fd7fbed1a4f45e85a1ecaf8630d82d8e0a028bed</td>
-        </tr>
-      
         <tr data-os="" data-arch="">
-          <td class="filename"><a class="download" href="https://github.com/xmidt-org/caduceus/releases/download/v0.2.2/RPM-GPG-KEY-xmidt">RPM-GPG-KEY-xmidt</a></td>
+          <td class="filename"><a class="download" href="https://github.com/xmidt-org/caduceus/releases/download/v0.2.3/caduceus-0.2.3.darwin-amd64">caduceus-0.2.3.darwin-amd64</a></td>
           <td></td>
           <td></td>
-          <td>0.00 MiB</td>
-          <td>gpg</td>
+          <td>24.59 MiB</td>
+          <td></td>
           <td class="checksum"></td>
         </tr>
       
         <tr data-os="" data-arch="">
-          <td class="filename"><a class="download" href="https://github.com/xmidt-org/caduceus/releases/download/v0.2.2/sha256sums.txt">sha256sums.txt</a></td>
+          <td class="filename"><a class="download" href="https://github.com/xmidt-org/caduceus/releases/download/v0.2.3/caduceus-0.2.3.linux-amd64">caduceus-0.2.3.linux-amd64</a></td>
           <td></td>
           <td></td>
-          <td>0.00 MiB</td>
+          <td>24.91 MiB</td>
           <td></td>
           <td class="checksum"></td>
         </tr>
@@ -276,7 +249,7 @@
           <td colspan="5">
             <strong></strong>
             
-            <small><a href="https://github.com/xmidt-org/gungnir/releases/tag/v0.13.0">Release notes</a></small>
+            <small><a href="https://github.com/xmidt-org/gungnir/releases/tag/v0.13.1">Release notes</a></small>
           </td>
         </tr>
         <tr class="first">
@@ -291,7 +264,7 @@
       <tbody>
       
         <tr data-os="" data-arch="">
-          <td class="filename"><a class="download" href="https://github.com/xmidt-org/gungnir/releases/download/v0.13.0/gungnir-0.13.0.darwin-amd64">gungnir-0.13.0.darwin-amd64</a></td>
+          <td class="filename"><a class="download" href="https://github.com/xmidt-org/gungnir/releases/download/v0.13.1/gungnir-0.13.1.darwin-amd64">gungnir-0.13.1.darwin-amd64</a></td>
           <td></td>
           <td></td>
           <td>19.98 MiB</td>
@@ -300,7 +273,7 @@
         </tr>
       
         <tr data-os="" data-arch="">
-          <td class="filename"><a class="download" href="https://github.com/xmidt-org/gungnir/releases/download/v0.13.0/gungnir-0.13.0.linux-amd64">gungnir-0.13.0.linux-amd64</a></td>
+          <td class="filename"><a class="download" href="https://github.com/xmidt-org/gungnir/releases/download/v0.13.1/gungnir-0.13.1.linux-amd64">gungnir-0.13.1.linux-amd64</a></td>
           <td></td>
           <td></td>
           <td>20.12 MiB</td>
@@ -322,7 +295,7 @@
           <td colspan="5">
             <strong></strong>
             
-            <small><a href="https://github.com/xmidt-org/heimdall/releases/tag/v0.2.0">Release notes</a></small>
+            <small><a href="https://github.com/xmidt-org/heimdall/releases/tag/v0.3.0">Release notes</a></small>
           </td>
         </tr>
         <tr class="first">
@@ -337,19 +310,19 @@
       <tbody>
       
         <tr data-os="" data-arch="">
-          <td class="filename"><a class="download" href="https://github.com/xmidt-org/heimdall/releases/download/v0.2.0/heimdall-0.2.0.darwin-amd64">heimdall-0.2.0.darwin-amd64</a></td>
+          <td class="filename"><a class="download" href="https://github.com/xmidt-org/heimdall/releases/download/v0.3.0/heimdall-0.3.0.darwin-amd64">heimdall-0.3.0.darwin-amd64</a></td>
           <td></td>
           <td></td>
-          <td>16.51 MiB</td>
+          <td>16.60 MiB</td>
           <td></td>
           <td class="checksum"></td>
         </tr>
       
         <tr data-os="" data-arch="">
-          <td class="filename"><a class="download" href="https://github.com/xmidt-org/heimdall/releases/download/v0.2.0/heimdall-0.2.0.linux-amd64">heimdall-0.2.0.linux-amd64</a></td>
+          <td class="filename"><a class="download" href="https://github.com/xmidt-org/heimdall/releases/download/v0.3.0/heimdall-0.3.0.linux-amd64">heimdall-0.3.0.linux-amd64</a></td>
           <td></td>
           <td></td>
-          <td>16.63 MiB</td>
+          <td>16.73 MiB</td>
           <td></td>
           <td class="checksum"></td>
         </tr>
@@ -368,7 +341,7 @@
           <td colspan="5">
             <strong></strong>
             
-            <small><a href="https://github.com/xmidt-org/svalinn/releases/tag/v0.14.0">Release notes</a></small>
+            <small><a href="https://github.com/xmidt-org/svalinn/releases/tag/v0.14.1">Release notes</a></small>
           </td>
         </tr>
         <tr class="first">
@@ -383,19 +356,10 @@
       <tbody>
       
         <tr data-os="" data-arch="">
-          <td class="filename"><a class="download" href="https://github.com/xmidt-org/svalinn/releases/download/v0.14.0/svalinn-0.14.0.darwin-amd64">svalinn-0.14.0.darwin-amd64</a></td>
+          <td class="filename"><a class="download" href="https://github.com/xmidt-org/svalinn/releases/download/v0.14.1/svalinn-0.14.1.darwin-amd64">svalinn-0.14.1.darwin-amd64</a></td>
           <td></td>
           <td></td>
-          <td>19.58 MiB</td>
-          <td></td>
-          <td class="checksum"></td>
-        </tr>
-      
-        <tr data-os="" data-arch="">
-          <td class="filename"><a class="download" href="https://github.com/xmidt-org/svalinn/releases/download/v0.14.0/svalinn-0.14.0.linux-amd64">svalinn-0.14.0.linux-amd64</a></td>
-          <td></td>
-          <td></td>
-          <td>19.72 MiB</td>
+          <td>19.84 MiB</td>
           <td></td>
           <td class="checksum"></td>
         </tr>


### PR DESCRIPTION
Ran into a few issues running `make bundle`
```
bundle config build.nokogiri --use-system-libraries
bundle install --path vendor
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path 'vendor'`, and stop using this flag
Fetching gem metadata from https://rubygems.org/............
nanoc-4.11.0 requires ruby version ~> 2.4, which is incompatible with the current version, ruby 2.3.7p456
make: *** [bundle] Error 5
```

I install ruby 2.4 but it still failed.