### PR TITLE
qos partner_ids clarification

### DIFF
--- a/content/docs/wrp/simple-messages.md
+++ b/content/docs/wrp/simple-messages.md
@@ -118,7 +118,7 @@ be added as appropriate.
     * The `source` SHALL be the component that cannot process the event further.
     * The `dest` SHALL be the original requesting `source` address.
     * The `content_type` and `payload` SHALL be omitted & set to empty, or may set to `application/text` and text to help describe the result.  **DO NOT** process this text beyond for logging/debugging.
-    * The `partner_ids` SHALL be the same as the original message.
+    * The `partner_ids` SHALL be the same as the original message and from the Themis token. If there is a difference, then the value of the Themis token will be used simply becuase Themis is used as a security authority.
     * The `headers` SHOULD generally be the same as the original message, except where updating their values is correct.  Example: tracing headers should be honored & updated.
     * The `metadata` map SHALL be populated with the original data or set to empty.
     * The `session_id` MAY be added by the cloud.

--- a/content/docs/wrp/simple-messages.md
+++ b/content/docs/wrp/simple-messages.md
@@ -118,7 +118,7 @@ be added as appropriate.
     * The `source` SHALL be the component that cannot process the event further.
     * The `dest` SHALL be the original requesting `source` address.
     * The `content_type` and `payload` SHALL be omitted & set to empty, or may set to `application/text` and text to help describe the result.  **DO NOT** process this text beyond for logging/debugging.
-    * The `partner_ids` SHALL be the same as the original message and from the Themis token. If there is a difference, then the value of the Themis token will be used simply becuase Themis is used as a security authority.
+    * The `partner_ids` SHALL be the same as the original message. If there is a difference between the partner-id in the original message when compared to the partner-id from the themis token, the value of the themis token will be used.
     * The `headers` SHOULD generally be the same as the original message, except where updating their values is correct.  Example: tracing headers should be honored & updated.
     * The `metadata` map SHALL be populated with the original data or set to empty.
     * The `session_id` MAY be added by the cloud.

--- a/content/docs/wrp/simple-messages.md
+++ b/content/docs/wrp/simple-messages.md
@@ -118,7 +118,7 @@ be added as appropriate.
     * The `source` SHALL be the component that cannot process the event further.
     * The `dest` SHALL be the original requesting `source` address.
     * The `content_type` and `payload` SHALL be omitted & set to empty, or may set to `application/text` and text to help describe the result.  **DO NOT** process this text beyond for logging/debugging.
-    * The `partner_ids` SHALL be the same as the original message. If there is a difference between the partner-id in the original message when compared to the partner-id from the themis token, the value of the themis token will be used.
+    * The `partner_ids` SHALL be the same as the original message unless the Themis token has a different value. If there is a difference, the value of the Themis token will be used because the Themis token is a validated trust authority.
     * The `headers` SHOULD generally be the same as the original message, except where updating their values is correct.  Example: tracing headers should be honored & updated.
     * The `metadata` map SHALL be populated with the original data or set to empty.
     * The `session_id` MAY be added by the cloud.


### PR DESCRIPTION
clarify what happens if there's difference between the  partner-id from the original message and themis token